### PR TITLE
Fix for errors from code analysis

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -21,6 +21,7 @@ ratings:
    - "**.py"
 
 exclude_paths:
+- "**/.tox/*"
 - "**/test_*"
 - "**/setup.py"
 - "**/resources/**"


### PR DESCRIPTION
resolves #78 
CodeClimate was analyzing temporary .tox files
