### PR TITLE
Implement caching on config APIs, extend them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,12 @@ verify:
 
 cleanup:
 	@echo "---- Cleaning up Audiopyle app ----"
+	@rm -rf ./backend/.mypy_cache
+	@rm -rf ./backend/.pytest_cache
+	@rm -rf ./backend/.coverage
+	@rm -rf ./frontend/node_modules
+	@rm -rf ./spectacle_docs
+	@rm -rf ./scripts/audiopyle-*.whl
 	@docker-compose -f ./scripts/docker-compose.yml down
 	@docker-compose -f ./scripts/docker-compose-ci.yml down
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ To start the app, follow these steps:
     - `worker/volumes`
 - do `make run` from the directory with `Makefile`
 - docker should pull the audiopyle images now
-- do `GET` on `http://localhost:8080/` to check the audiopyle status
-- there's no UI available (*yet*), you can use REST API
+- do `GET` on `http://localhost:8080/` to check the audiopyle status via API
+- there's no UI available (*yet, work in progress*), you can use REST API
 
 ### App REST API description
 Hosted audiopyle API documentation is available from [GitHub Pages](https://emkor.github.io/audiopyle/api/)

--- a/backend/audiopyle/api/config.py
+++ b/backend/audiopyle/api/config.py
@@ -15,7 +15,7 @@ class PluginConfigListApi(AbstractRestApi):
     def get(self, **kwargs) -> str:
         api_request = build_request(request, **kwargs)
         try:
-            api_response = ApiResponse(status_code=HttpStatusCode.ok, payload=self.plugin_config_provider.get_plugins())
+            api_response = ApiResponse(status_code=HttpStatusCode.ok, payload=self.plugin_config_provider.get_plugin_names())
         except Exception:
             api_response = ApiResponse(HttpStatusCode.not_found,
                                        {"message": "Could not find config file: {}".format(PLUGIN_CONFIG_FILE_NAME)})

--- a/backend/audiopyle/api/config.py
+++ b/backend/audiopyle/api/config.py
@@ -47,14 +47,59 @@ class PluginConfigApi(AbstractRestApi):
         return build_response(api_response)
 
 
-class MetricActiveConfigApi(AbstractRestApi):
+class MetricConfigListApi(AbstractRestApi):
     def __init__(self, metric_config_provider: MetricConfigProvider) -> None:
         self.metric_config_provider = metric_config_provider
 
     def get(self, **kwargs) -> str:
         api_request = build_request(request, **kwargs)
         try:
-            api_response = ApiResponse(status_code=HttpStatusCode.ok, payload=self.metric_config_provider.get_all())
+            api_response = ApiResponse(status_code=HttpStatusCode.ok,
+                                       payload=self.metric_config_provider.get_metric_names())
+        except Exception:
+            api_response = ApiResponse(HttpStatusCode.not_found,
+                                       {"message": "Could not find config file: {}".format(PLUGIN_CONFIG_FILE_NAME)})
+        log_api_call(api_request, api_response)
+        return build_response(api_response)
+
+
+class MetricByNameApi(AbstractRestApi):
+    def __init__(self, metric_config_provider: MetricConfigProvider) -> None:
+        self.metric_config_provider = metric_config_provider
+
+    def get(self, **kwargs) -> str:
+        api_request = build_request(request, **kwargs)
+        try:
+            metric_name = api_request.query_params["name"]
+            api_response = ApiResponse(status_code=HttpStatusCode.ok,
+                                       payload=self.metric_config_provider.get_by_name(metric_name))
+        except KeyError:
+            api_response = ApiResponse(HttpStatusCode.bad_request,
+                                       payload={"message": "Could not find metric name parameter in URL: {}".format(
+                                           api_request.url)})
+        except Exception:
+            api_response = ApiResponse(HttpStatusCode.not_found,
+                                       {"message": "Could not find config file: {}".format(PLUGIN_CONFIG_FILE_NAME)})
+        log_api_call(api_request, api_response)
+        return build_response(api_response)
+
+
+class MetricsByPluginApi(AbstractRestApi):
+    def __init__(self, metric_config_provider: MetricConfigProvider) -> None:
+        self.metric_config_provider = metric_config_provider
+
+    def get(self, **kwargs) -> str:
+        api_request = build_request(request, **kwargs)
+        try:
+            vendor = api_request.query_params["vendor"]
+            name = api_request.query_params["name"]
+            output = api_request.query_params["output"]
+            plugin_key = "{}:{}:{}".format(vendor, name, output)
+            api_response = ApiResponse(status_code=HttpStatusCode.ok,
+                                       payload=self.metric_config_provider.get_metric_names_for_plugin(plugin_key))
+        except KeyError:
+            message = "Could not find metric plugin parameters in URL: {}".format(api_request.url)
+            api_response = ApiResponse(HttpStatusCode.bad_request, payload={"message": message})
         except Exception:
             api_response = ApiResponse(HttpStatusCode.not_found,
                                        {"message": "Could not find config file: {}".format(PLUGIN_CONFIG_FILE_NAME)})

--- a/backend/audiopyle/api/config.py
+++ b/backend/audiopyle/api/config.py
@@ -8,14 +8,38 @@ from audiopyle.lib.services.plugin_config_provider import PluginConfigProvider
 from audiopyle.lib.utils.file_system import PLUGIN_CONFIG_FILE_NAME
 
 
-class PluginActiveConfigApi(AbstractRestApi):
+class PluginConfigListApi(AbstractRestApi):
     def __init__(self, plugin_config_provider: PluginConfigProvider) -> None:
         self.plugin_config_provider = plugin_config_provider
 
     def get(self, **kwargs) -> str:
         api_request = build_request(request, **kwargs)
         try:
-            api_response = ApiResponse(status_code=HttpStatusCode.ok, payload=self.plugin_config_provider.get_all())
+            api_response = ApiResponse(status_code=HttpStatusCode.ok, payload=self.plugin_config_provider.get_plugins())
+        except Exception:
+            api_response = ApiResponse(HttpStatusCode.not_found,
+                                       {"message": "Could not find config file: {}".format(PLUGIN_CONFIG_FILE_NAME)})
+        log_api_call(api_request, api_response)
+        return build_response(api_response)
+
+
+class PluginConfigApi(AbstractRestApi):
+    def __init__(self, plugin_config_provider: PluginConfigProvider) -> None:
+        self.plugin_config_provider = plugin_config_provider
+
+    def get(self, **kwargs) -> str:
+        api_request = build_request(request, **kwargs)
+        try:
+            vendor = api_request.query_params["vendor"]
+            name = api_request.query_params["name"]
+            output = api_request.query_params["output"]
+            plugin_key = "{}:{}:{}".format(vendor, name, output)
+            api_response = ApiResponse(status_code=HttpStatusCode.ok,
+                                       payload=self.plugin_config_provider.get_for_plugin(plugin_key))
+        except KeyError:
+            api_response = ApiResponse(HttpStatusCode.bad_request,
+                                       payload={"message": "Could not find plugin key parameter in URL: {}".format(
+                                           api_request.url)})
         except Exception:
             api_response = ApiResponse(HttpStatusCode.not_found,
                                        {"message": "Could not find config file: {}".format(PLUGIN_CONFIG_FILE_NAME)})

--- a/backend/audiopyle/api_main.py
+++ b/backend/audiopyle/api_main.py
@@ -27,7 +27,8 @@ from audiopyle.lib.utils.logger import setup_logger, get_logger
 from audiopyle.api.audio_file import AudioFileListApi, AudioFileDetailApi
 from audiopyle.api.audio_tag import AudioTagApi
 from audiopyle.api.automation import AutomationApi
-from audiopyle.api.config import PluginConfigListApi, MetricActiveConfigApi, PluginConfigApi
+from audiopyle.api.config import PluginConfigListApi, MetricConfigListApi, PluginConfigApi, MetricByNameApi, \
+    MetricsByPluginApi
 from audiopyle.api.metric import MetricDefinitionListApi, MetricDefinitionDetailsApi, MetricValueListApi, \
     MetricValueDetailsApi
 from audiopyle.api.plugin import PluginListApi, PluginDetailApi
@@ -114,9 +115,15 @@ def start_app(logger: Logger, host: str, port: int):
     app.add_url_rule("/config/plugin/<vendor>/<name>/<output>",
                      view_func=PluginConfigApi.as_view('plugin_config_api',
                                                        plugin_config_provider=plugin_config_provider))
+    app.add_url_rule("/config/plugin/<vendor>/<name>/<output>/metric",
+                     view_func=MetricsByPluginApi.as_view('plugin_metric_names_api',
+                                                          metric_config_provider=metric_config_provider))
     app.add_url_rule("/config/metric",
-                     view_func=MetricActiveConfigApi.as_view('metric_config_api',
-                                                             metric_config_provider=metric_config_provider))
+                     view_func=MetricConfigListApi.as_view('metric_config_list_api',
+                                                           metric_config_provider=metric_config_provider))
+    app.add_url_rule("/config/metric/<name>",
+                     view_func=MetricByNameApi.as_view('metric_config_by_name_api',
+                                                       metric_config_provider=metric_config_provider))
     app.add_url_rule("/audio",
                      view_func=AudioFileListApi.as_view('audio_list_api',
                                                         file_store=audio_file_store))

--- a/backend/audiopyle/api_main.py
+++ b/backend/audiopyle/api_main.py
@@ -27,7 +27,7 @@ from audiopyle.lib.utils.logger import setup_logger, get_logger
 from audiopyle.api.audio_file import AudioFileListApi, AudioFileDetailApi
 from audiopyle.api.audio_tag import AudioTagApi
 from audiopyle.api.automation import AutomationApi
-from audiopyle.api.config import PluginActiveConfigApi, MetricActiveConfigApi
+from audiopyle.api.config import PluginConfigListApi, MetricActiveConfigApi, PluginConfigApi
 from audiopyle.api.metric import MetricDefinitionListApi, MetricDefinitionDetailsApi, MetricValueListApi, \
     MetricValueDetailsApi
 from audiopyle.api.plugin import PluginListApi, PluginDetailApi
@@ -39,6 +39,7 @@ app = Flask(__name__)
 
 allowed_origins = read_env_var("API_ALLOWED_ORIGIN", str, "http://localhost:8008,http://ui.local:8080").split(",")
 cors = CORS(app, origins=allowed_origins, methods=["GET", "POST", "DELETE", "PUT"])
+
 
 def main():
     setup_logger()
@@ -108,8 +109,11 @@ def start_app(logger: Logger, host: str, port: int):
                      view_func=MetricValueDetailsApi.as_view('metric_value_details_by_definition_api',
                                                              metric_repo=metric_value_repo))
     app.add_url_rule("/config/plugin",
-                     view_func=PluginActiveConfigApi.as_view('plugin_config_api',
-                                                             plugin_config_provider=plugin_config_provider))
+                     view_func=PluginConfigListApi.as_view('plugin_config_list_api',
+                                                           plugin_config_provider=plugin_config_provider))
+    app.add_url_rule("/config/plugin/<vendor>/<name>/<output>",
+                     view_func=PluginConfigApi.as_view('plugin_config_api',
+                                                       plugin_config_provider=plugin_config_provider))
     app.add_url_rule("/config/metric",
                      view_func=MetricActiveConfigApi.as_view('metric_config_api',
                                                              metric_config_provider=metric_config_provider))

--- a/backend/audiopyle/lib/services/metric_config_provider.py
+++ b/backend/audiopyle/lib/services/metric_config_provider.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from audiopyle.lib.services.store_provider import JsonFileStore, StoreError
 from audiopyle.lib.utils.file_system import METRIC_CONFIG_FILE_NAME
@@ -29,6 +29,17 @@ class MetricConfigProvider(object):
                 plugin_config.update({metric_name: metric_config})
         return plugin_config
 
-    def get_by_name(self, metric_name):
-        full_config = self.get_all()
-        return full_config.get(metric_name, {}) if full_config is not None else {}
+    def get_by_name(self, metric_name) -> Dict[str, Any]:
+        full_config = self.get_all() or {}
+        return full_config.get(metric_name, {})
+
+    def get_metric_names(self) -> List[str]:
+        full_config = self.get_all() or {}
+        return list(full_config.keys())
+
+    def get_metric_names_for_plugin(self, plugin_full_key: str) -> List[str]:
+        metric_names = []
+        for metric_name, metric_config in (self.get_all() or {}).items():
+            if plugin_full_key == metric_config["plugin"]:
+                metric_names.append(metric_name)
+        return metric_names

--- a/backend/audiopyle/lib/services/metric_config_provider.py
+++ b/backend/audiopyle/lib/services/metric_config_provider.py
@@ -9,13 +9,16 @@ class MetricConfigProvider(object):
     def __init__(self, file_store: JsonFileStore, logger: Logger) -> None:
         self.file_store = file_store
         self.logger = logger
+        self._cached = None  # type: Optional[Dict[str, Dict[str, Any]]]
 
     def get_all(self) -> Optional[Dict[str, Any]]:
-        try:
-            return self.file_store.read(METRIC_CONFIG_FILE_NAME)  # type: ignore
-        except StoreError as e:
-            self.logger.warning(str(e))
-            return None
+        if self._cached is None:
+            try:
+                self._cached = self.file_store.read(METRIC_CONFIG_FILE_NAME)  # type: ignore
+            except StoreError as e:
+                self.logger.warning(str(e))
+                self._cached = None
+        return self._cached
 
     def get_for_plugin(self, plugin_full_key: str) -> Dict[str, Any]:
         plugin_config = {}

--- a/backend/audiopyle/lib/services/plugin_config_provider.py
+++ b/backend/audiopyle/lib/services/plugin_config_provider.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from audiopyle.lib.services.store_provider import JsonFileStore, StoreError
 from audiopyle.lib.utils.file_system import PLUGIN_CONFIG_FILE_NAME
@@ -21,5 +21,9 @@ class PluginConfigProvider(object):
         return self._cached
 
     def get_for_plugin(self, plugin_full_key: str) -> Dict[str, Any]:
-        full_config = self.get_all()
-        return full_config.get(plugin_full_key, {}) if full_config is not None else {}
+        full_config = self.get_all() or {}
+        return full_config.get(plugin_full_key, {})
+
+    def get_plugins(self) -> List[str]:
+        full_config = self.get_all() or {}
+        return list(full_config.keys())

--- a/backend/audiopyle/lib/services/plugin_config_provider.py
+++ b/backend/audiopyle/lib/services/plugin_config_provider.py
@@ -9,13 +9,16 @@ class PluginConfigProvider(object):
     def __init__(self, file_store: JsonFileStore, logger: Logger) -> None:
         self.file_store = file_store
         self.logger = logger
+        self._cached = None  # type: Optional[Dict[str, Dict[str, Any]]]
 
     def get_all(self) -> Optional[Dict[str, Any]]:
-        try:
-            return self.file_store.read(PLUGIN_CONFIG_FILE_NAME)  # type: ignore
-        except StoreError as e:
-            self.logger.warning(str(e))
-            return None
+        if self._cached is None:
+            try:
+                self._cached = self.file_store.read(PLUGIN_CONFIG_FILE_NAME)  # type: ignore
+            except StoreError as e:
+                self.logger.warning(str(e))
+                self._cached = None
+        return self._cached
 
     def get_for_plugin(self, plugin_full_key: str) -> Dict[str, Any]:
         full_config = self.get_all()

--- a/backend/audiopyle/lib/services/plugin_config_provider.py
+++ b/backend/audiopyle/lib/services/plugin_config_provider.py
@@ -24,6 +24,6 @@ class PluginConfigProvider(object):
         full_config = self.get_all() or {}
         return full_config.get(plugin_full_key, {})
 
-    def get_plugins(self) -> List[str]:
+    def get_plugin_names(self) -> List[str]:
         full_config = self.get_all() or {}
         return list(full_config.keys())

--- a/open_api_docs.yml
+++ b/open_api_docs.yml
@@ -254,6 +254,21 @@ definitions:
         description: "Time (in seconds) taken by inserting data related to extraction to DB"
         type: "number"
 paths:
+  /:
+    get:
+      description: "Returns Audiopyle API status"
+      responses:
+        200:
+          description: "API status"
+          schema:
+            type: object
+            properties:
+              status:
+                type: "string"
+          examples:
+            application/json: {
+              "status": "ok"
+            }
   /audio:
     get:
       description: "Returns list of available audio file names"

--- a/open_api_docs.yml
+++ b/open_api_docs.yml
@@ -7,11 +7,11 @@ info:
 host: "localhost:8080"
 basePath: "/"
 schemes:
-  - "http"
+- "http"
 consumes:
-  - "application/json"
+- "application/json"
 produces:
-  - "application/json"
+- "application/json"
 definitions:
   ErrorModel:
     type: "object"
@@ -23,11 +23,11 @@ definitions:
   FileDetail:
     type: "object"
     required:
-      - "file_name"
-      - "size"
-      - "created_on"
-      - "last_modification"
-      - "last_access"
+    - "file_name"
+    - "size"
+    - "created_on"
+    - "last_modification"
+    - "last_access"
     properties:
       file_name:
         type: "string"
@@ -49,10 +49,10 @@ definitions:
   VampPlugin:
     type: "object"
     required:
-      - "vendor"
-      - "name"
-      - "output"
-      - "library_file_name"
+    - "vendor"
+    - "name"
+    - "output"
+    - "library_file_name"
     properties:
       vendor:
         type: "string"
@@ -65,12 +65,12 @@ definitions:
   AudioTag:
     type: "object"
     required:
-      - "artist"
-      - "album"
-      - "title"
-      - "genre"
-      - "track"
-      - "date"
+    - "artist"
+    - "album"
+    - "title"
+    - "genre"
+    - "track"
+    - "date"
     properties:
       artist:
         type: "string"
@@ -89,8 +89,8 @@ definitions:
   MetricConfig:
     type: "object"
     required:
-      - "plugin"
-      - "transformation"
+    - "plugin"
+    - "transformation"
     properties:
       plugin:
         type: "string"
@@ -105,8 +105,8 @@ definitions:
   PluginConfig:
     type: "object"
     required:
-      - block_size
-      - step_size
+    - block_size
+    - step_size
     properties:
       block_size:
         type: "integer"
@@ -116,8 +116,8 @@ definitions:
   ExtractionRequest:
     type: "object"
     required:
-      - "audio_file_name"
-      - "plugin_full_key"
+    - "audio_file_name"
+    - "plugin_full_key"
     properties:
       task_id:
         type: "string"
@@ -133,9 +133,9 @@ definitions:
   MetricDefinition:
     type: "object"
     required:
-      - "name"
-      - "plugin"
-      - "transformation"
+    - "name"
+    - "plugin"
+    - "transformation"
     properties:
       name:
         type: "string"
@@ -146,7 +146,7 @@ definitions:
       transformation:
         type: "object"
         required:
-          - "name"
+        - "name"
         properties:
           name:
             type: "string"
@@ -157,14 +157,14 @@ definitions:
   MetricValue:
     type: "object"
     required:
-      - "count"
-      - "maximum"
-      - "mean"
-      - "median"
-      - "minimum"
-      - "standard_deviation"
-      - "sum"
-      - "variance"
+    - "count"
+    - "maximum"
+    - "mean"
+    - "median"
+    - "minimum"
+    - "standard_deviation"
+    - "sum"
+    - "variance"
     properties:
       count:
         type: "integer"
@@ -185,8 +185,8 @@ definitions:
   ExtractionStatus:
     type: "object"
     required:
-      - "task_id"
-      - "status"
+    - "task_id"
+    - "status"
     properties:
       task_id:
         type: "string"
@@ -219,14 +219,14 @@ definitions:
   ExtractionStats:
     type: "object"
     required:
-      - "task_id"
-      - "total_time"
-      - "compression_time"
-      - "data_stats_build_time"
-      - "encode_audio_time"
-      - "extraction_time"
-      - "metrics_extraction_time"
-      - "result_store_time"
+    - "task_id"
+    - "total_time"
+    - "compression_time"
+    - "data_stats_build_time"
+    - "encode_audio_time"
+    - "extraction_time"
+    - "metrics_extraction_time"
+    - "result_store_time"
     properties:
       task_id:
         type: "string"
@@ -280,9 +280,9 @@ paths:
               type: "string"
           examples:
             application/json: [
-                "102bpm_drum_loop.flac",
-                "102bpm_drum_loop.mp3"
-              ]
+              "102bpm_drum_loop.flac",
+              "102bpm_drum_loop.mp3"
+            ]
   /audio/{file_name}:
     get:
       description: "Returns list of available audio file names"
@@ -346,7 +346,7 @@ paths:
             $ref: "#/definitions/ErrorModel"
   /plugin:
     get:
-      description: "Returns list of available VAMP plugins"
+      description: "Returns list of available VAMP plugin full keys"
       responses:
         200:
           description: "List of available VAMP plugins"
@@ -477,7 +477,7 @@ paths:
       description: "Returns plugins for which there's available configuration"
       responses:
         200:
-          description: "Plugin keys list with config defined in JSON file"
+          description: "List of plugin keys with config defined in JSON file"
           schema:
             type: array
             items:
@@ -548,10 +548,10 @@ paths:
     get:
       description: "Returns metric values inserted by finished extractions"
       parameters:
-        - name: name
-          in: path
-          required: true
-          type: "string"
+      - name: name
+        in: path
+        required: true
+        type: "string"
       responses:
         200:
           description: "List of task_ids that extracted metric values for given metric definitions"
@@ -925,11 +925,11 @@ paths:
     get:
       description: "Lists metric definition names that were inserted by given extraction identified by task_id"
       parameters:
-        - name: task_id
-          in: path
-          required: true
-          type: "string"
-          format: "uuid"
+      - name: task_id
+        in: path
+        required: true
+        type: "string"
+        format: "uuid"
       responses:
         200:
           description: "Metric definition names"
@@ -1013,12 +1013,12 @@ paths:
               $ref: "#/definitions/ExtractionRequest"
           examples:
             application/json: [{
-               "audio_file_name": "102bpm_drum_loop.flac",
-               "metric_config": null,
-               "plugin_config": null,
-               "plugin_full_key": "vamp-example-plugins:spectralcentroid:logcentroid",
-               "uuid": "0b04c1b3-b366-5145-9248-6cb118d3be99"
-            }]
+                                 "audio_file_name": "102bpm_drum_loop.flac",
+                                 "metric_config": null,
+                                 "plugin_config": null,
+                                 "plugin_full_key": "vamp-example-plugins:spectralcentroid:logcentroid",
+                                 "uuid": "0b04c1b3-b366-5145-9248-6cb118d3be99"
+                               }]
         412:
           description: "Audio files directory or VAMP plugins directory is empty; could not generate requests"
           schema:

--- a/open_api_docs.yml
+++ b/open_api_docs.yml
@@ -203,8 +203,8 @@ definitions:
     - "task_id"
     properties:
       data_shape:
-        description: "3-element array describing element count in X, Y, Z dimensions"
-        type: array
+        description: "3-element describing element count in X, Y, Z dimensions"
+        type: "array"
         items:
           type: "integer"
       feature_size:
@@ -260,7 +260,7 @@ paths:
         200:
           description: "API status"
           schema:
-            type: object
+            type: "object"
             properties:
               status:
                 type: "string"
@@ -275,7 +275,7 @@ paths:
         200:
           description: "A list of file names"
           schema:
-            type: array
+            type: "array"
             items:
               type: "string"
           examples:
@@ -479,7 +479,7 @@ paths:
         200:
           description: "List of plugin keys with config defined in JSON file"
           schema:
-            type: array
+            type: "array"
             items:
               type: "string"
           examples:
@@ -518,7 +518,7 @@ paths:
         200:
           description: "Metric definition names"
           schema:
-            type: array
+            type: "array"
             items:
               type: "string"
           examples:
@@ -556,7 +556,7 @@ paths:
         200:
           description: "List of task_ids that extracted metric values for given metric definitions"
           schema:
-            type: array
+            type: "array"
             items:
               type: "string"
               format: "uuid"
@@ -631,7 +631,7 @@ paths:
         200:
           description: "List of task IDs from received requests"
           schema:
-            type: array
+            type: "array"
             items:
               type: "string"
           examples:
@@ -934,7 +934,7 @@ paths:
         200:
           description: "Metric definition names"
           schema:
-            type: array
+            type: "array"
             items:
               type: "string"
           examples:
@@ -1008,7 +1008,7 @@ paths:
         202:
           description: "Returns details of generated requests"
           schema:
-            type: array
+            type: "array"
             items:
               $ref: "#/definitions/ExtractionRequest"
           examples:

--- a/open_api_docs.yml
+++ b/open_api_docs.yml
@@ -412,18 +412,38 @@ paths:
             $ref: "#/definitions/ErrorModel"
   /config/plugin:
     get:
-      description: "Returns available plugin configuration"
+      description: "Returns plugins for which there's available configuration"
       responses:
         200:
-          description: "Content of plugin config JSON file"
+          description: "Plugin keys list with config defined in JSON file"
+          schema:
+            type: array
+            items:
+              type: "string"
+          examples:
+            application/json: [
+              "vamp-example-plugins:amplitudefollower:amplitude"
+            ]
+        400:
+          description: "Vendor, name or output parameter were not given"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+        404:
+          description: "There was no plugin config file found"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+  /config/plugin/{vendor}/{name}/{output}:
+    get:
+      description: "Returns available configuration for given plugin"
+      responses:
+        200:
+          description: "Content of plugin config JSON file for given plugin"
           schema:
             $ref: "#/definitions/PluginConfig"
           examples:
             application/json: {
-              "vamp-example-plugins:amplitudefollower:amplitude": {
-                "block_size":4096,
-                "step_size":4096
-              }
+              "block_size": 4096,
+              "step_size": 4096
             }
         404:
           description: "There was no plugin config file found"

--- a/open_api_docs.yml
+++ b/open_api_docs.yml
@@ -88,32 +88,31 @@ definitions:
         type: "integer"
   MetricConfig:
     type: "object"
-    additionalProperties:
-      type: "object"
-      required:
-        - "plugin"
-        - "transformation"
-      properties:
-        plugin:
-          type: "string"
-        transformation:
-          type: "object"
-          properties:
-            name:
-              type: "string"
-            kwargs:
-              type: "object"
-              additionalProperties: true
+    required:
+      - "plugin"
+      - "transformation"
+    properties:
+      plugin:
+        type: "string"
+      transformation:
+        type: "object"
+        properties:
+          name:
+            type: "string"
+          kwargs:
+            type: "object"
+            additionalProperties: true
   PluginConfig:
     type: "object"
-    additionalProperties:
-      type: "object"
-      properties:
-        block_size:
-          type: "integer"
-        step_size:
-          type: "integer"
-      additionalProperties: true
+    required:
+      - block_size
+      - step_size
+    properties:
+      block_size:
+        type: "integer"
+      step_size:
+        type: "integer"
+    additionalProperties: true
   ExtractionRequest:
     type: "object"
     required:
@@ -386,7 +385,42 @@ paths:
           schema:
             $ref: "#/definitions/ErrorModel"
         404:
-          description: "Plugin with given vendor, name or output dos not exist"
+          description: "Plugin with given vendor, name or output does not exist"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+  /plugin/{vendor}/{name}/{output}/metric:
+    get:
+      description: "Returns Metric defined for given plugin"
+      parameters:
+      - name: vendor
+        in: path
+        required: true
+        type: "string"
+      - name: name
+        in: path
+        required: true
+        type: "string"
+      - name: output
+        in: path
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "List of Metric names that are using given plugin as input"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+          examples:
+            application/json: [
+              "bbc_rhythm_onset_average"
+            ]
+        400:
+          description: "Vendor, name or output parameter were not given"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+        404:
+          description: "Plugin with given vendor, name or output does not exist"
           schema:
             $ref: "#/definitions/ErrorModel"
   /config/metric:
@@ -395,6 +429,30 @@ paths:
       responses:
         200:
           description: "Content of metric config JSON file"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+          examples:
+            application/json: [
+              "bbc_energy_rms",
+              "bbc_intensity_overall"
+            ]
+        404:
+          description: "There was no metric config file found"
+          schema:
+            $ref: "#/definitions/ErrorModel"
+  /config/metric/{name}:
+    get:
+      description: "Returns metric definition with given name"
+      parameters:
+      - name: name
+        in: path
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "Metric definition from configuration file"
           schema:
             $ref: "#/definitions/MetricConfig"
           examples:
@@ -406,8 +464,12 @@ paths:
                 }
               }
             }
+        400:
+          description: "Metric name parameter was not given"
+          schema:
+            $ref: "#/definitions/ErrorModel"
         404:
-          description: "There was no metric config file found"
+          description: "Metric with given name does not exist"
           schema:
             $ref: "#/definitions/ErrorModel"
   /config/plugin:


### PR DESCRIPTION
- config APIs reading JSON file were hitting the file on each request, which is inefficient
- updated them with caching the config once during application boot and responding with cached values
- extended plugin config API to match REST specification
- extended metric config API to match REST specification
- added endpoint metrics-for-plugin to use in IU in near future